### PR TITLE
Fix exception on empty organization L1

### DIFF
--- a/JSON_to_MODS.py
+++ b/JSON_to_MODS.py
@@ -785,7 +785,7 @@ departments_info={
 
 # the first argument is the acronym of the school, while the seconds is a string name of a department
 def departments_acronym(l1, s2):
-    if l1 is None:
+    if l1 not in departments_info:
         return None
     for d in departments_info[l1]:
         if s2 == departments_info[l1][d]['swe'] or s2 == departments_info[l1][d]['eng']:

--- a/JSON_to_MODS.py
+++ b/JSON_to_MODS.py
@@ -785,6 +785,8 @@ departments_info={
 
 # the first argument is the acronym of the school, while the seconds is a string name of a department
 def departments_acronym(l1, s2):
+    if l1 is None:
+        return None
     for d in departments_info[l1]:
         if s2 == departments_info[l1][d]['swe'] or s2 == departments_info[l1][d]['eng']:
             return d


### PR DESCRIPTION
Pdf:s with no L1 throws key exceptions in `departments_info[l1]:`. It's better to just return None to continue execution.

Example:
![image](https://github.com/user-attachments/assets/bab2aacf-d91c-44cb-9e83-872f25d5efac)